### PR TITLE
Scale images + fix cache

### DIFF
--- a/Monopoly/Models/Cases/AbstractCase.cs
+++ b/Monopoly/Models/Cases/AbstractCase.cs
@@ -11,8 +11,15 @@ namespace Monopoly.Models.Cases
 {
     public abstract class AbstractCase
     {
+        // Size of a "standard" board case (this doesn't apply to the corner cases)
         public const int BOARD_CASE_WIDTH = 123;
         public const int BOARD_CASE_HEIGHT = 195;
+
+        /// <summary>
+        /// Cache the images relative to this case.
+        /// Since all the images have to be generated, caching them improves drastically performance.
+        /// </summary>
+        protected Dictionary<string, Image> imageCache = new Dictionary<string, Image>();
 
         /// <summary>
         /// What happens when a player lands on the case?

--- a/Monopoly/Models/Cases/CardCase.cs
+++ b/Monopoly/Models/Cases/CardCase.cs
@@ -9,8 +9,6 @@ namespace Monopoly.Models.Cases
 {
     class CardCase : AbstractCase
     {
-        private Image cacheCaseImage = null;
-
         public CardType Type { get; private set; }
 
         /// <summary>
@@ -33,8 +31,8 @@ namespace Monopoly.Models.Cases
 
         public override Image GetBoardCaseImage()
         {
-            if (cacheCaseImage != null)
-                return cacheCaseImage;
+            if (imageCache.ContainsKey("board-case"))
+                return imageCache["board-case"];
 
             Image img = base.GetBoardCaseImage();
 
@@ -49,6 +47,7 @@ namespace Monopoly.Models.Cases
                 g.DrawImage(image, new RectangleF(rectangle.X + 10, 87, rectangle.Width - 20, rectangle.Width - 20));
             }
 
+            imageCache["board-case"] = img;
             return img;
         }
 

--- a/Monopoly/Models/Cases/PropertyCase.cs
+++ b/Monopoly/Models/Cases/PropertyCase.cs
@@ -42,10 +42,11 @@ namespace Monopoly.Models.Cases
         /// <summary>
         /// Create a blank (empty) property card image that can be extended by subclasses
         /// </summary>
+        /// <param name="scale">Scale of the image (default = 1)</param>
         /// <returns>A blank image of the size of the property card</returns>
-        public virtual Image GetPropertyCardImage()
+        public virtual Image GetPropertyCardImage(int scale)
         {
-            Image image = new Bitmap(PROPERTY_CARD_WIDTH, PROPERTY_CARD_HEIGHT);
+            Image image = new Bitmap(PROPERTY_CARD_WIDTH * scale, PROPERTY_CARD_HEIGHT * scale);
 
             using (Graphics g = Graphics.FromImage(image))
             {
@@ -59,15 +60,16 @@ namespace Monopoly.Models.Cases
         /// <summary>
         /// Draw a line of text on the card to indicate the price
         /// </summary>
-        /// <param name="g"></param>
-        /// <param name="y"></param>
+        /// <param name="g">Graphics object</param>
+        /// <param name="y">Y position of the price</param>
         /// <param name="name">Key of the price</param>
         /// <param name="price">Value of the price</param>
-        protected void DrawPrice(Graphics g, int y, string name, int price)
+        /// <param name="scale">Scale of the text to draw</param>
+        protected void DrawPrice(Graphics g, int scale, int y, string name, int price)
         {
-            g.DrawString(name, new Font("Arial", 6), new SolidBrush(Color.FromArgb(200, Color.White)), new PointF(2.5F, y + 0.5F));
-            g.DrawImage(Properties.Resources.Flouzz, new RectangleF(65, y + 2.5F, 6, 6));
-            g.DrawString(price.ToString(), new Font("Arial", 7, FontStyle.Bold), Brushes.White, new PointF(71, y));
+            g.DrawString(name, new Font("Arial", 6 * scale), new SolidBrush(Color.FromArgb(200, Color.White)), new PointF(2.5F * scale, y + 0.5F * scale));
+            g.DrawImage(Properties.Resources.Flouzz, new RectangleF(65 * scale, y + 2.5F * scale, 6 * scale, 6 * scale));
+            g.DrawString(price.ToString(), new Font("Arial", 7 * scale, FontStyle.Bold), Brushes.White, new PointF(71 * scale, y));
         }
 
         /// <summary>

--- a/Monopoly/Models/Cases/StationProperty.cs
+++ b/Monopoly/Models/Cases/StationProperty.cs
@@ -13,16 +13,13 @@ namespace Monopoly.Models.Cases
         const int STATION_PRICE = 200;
         private static readonly int[] STATION_RENTS = new int[] { 25, 50, 100, 200 };
 
-        private Image cacheCaseImage = null;
-        private Image cachePropertyImage = null;
-
         public StationProperty(string name) : base(name, STATION_PRICE) {
         }
 
         public override Image GetBoardCaseImage()
         {
-            if (cacheCaseImage != null)
-                return cacheCaseImage;
+            if (imageCache.ContainsKey("board-case"))
+                return imageCache["board-case"];
 
             Image img = base.GetBoardCaseImage();
 
@@ -46,16 +43,16 @@ namespace Monopoly.Models.Cases
                 g.DrawImage(Properties.Resources.Gare, new RectangleF(rectangle.X + 10, 87, rectangle.Width - 20, rectangle.Width - 20));
             }
 
-            cacheCaseImage = img;
+            imageCache["board-case"] = img;
             return img;
         }
 
-        public override Image GetPropertyCardImage()
+        public override Image GetPropertyCardImage(int scale)
         {
-            if (cachePropertyImage != null)
-                return cachePropertyImage;
+            if (imageCache.ContainsKey($"property-card-{scale}x"))
+                return imageCache[$"property-card-{scale}x"];
 
-            Image img = base.GetPropertyCardImage();
+            Image img = base.GetPropertyCardImage(scale);
 
             using (Graphics g = Graphics.FromImage(img))
             {
@@ -70,22 +67,22 @@ namespace Monopoly.Models.Cases
                     name = new string(n);
                 }
 
-                g.DrawImage(Properties.Resources.Gare, new RectangleF(rectangle.X + 10, 10, rectangle.Width - 20, rectangle.Width - 20));
-                g.DrawString(name, new Font("Arial", 10), Brushes.White, new PointF(2.5F, 2.5F + 5));
+                g.DrawImage(Properties.Resources.Gare, new RectangleF(rectangle.X + 10 * scale, 10 * scale, rectangle.Width - 20 * scale, rectangle.Width - 20 * scale));
+                g.DrawString(name, new Font("Arial", 10 * scale), Brushes.White, new PointF(2.5F * scale, 2.5F * scale + 5 * scale));
 
                 // Rent
-                int y = 65;
-                int height = 12;
-                DrawPrice(g, y += height, "Loyer", STATION_RENTS[0]);
-                DrawPrice(g, y += height, "Avec 2 gare", STATION_RENTS[1]);
-                DrawPrice(g, y += height, "Avec 3 gares", STATION_RENTS[2]);
-                DrawPrice(g, y += height, "Avec 4 gares", STATION_RENTS[3]);
+                int y = 65 * scale;
+                int height = 12 * scale;
+                DrawPrice(g, scale, y += height, "Loyer", STATION_RENTS[0]);
+                DrawPrice(g, scale, y += height, "Avec 2 gare", STATION_RENTS[1]);
+                DrawPrice(g, scale, y += height, "Avec 3 gares", STATION_RENTS[2]);
+                DrawPrice(g, scale, y += height, "Avec 4 gares", STATION_RENTS[3]);
 
-                DrawPrice(g, y += 17, "Hypothèque", STATION_PRICE / 2);
+                DrawPrice(g, scale, y += 17 * scale, "Hypothèque", STATION_PRICE / 2);
 
             }
 
-            cachePropertyImage = img;
+            imageCache[$"property-card-{scale}x"] = img;
             return img;
         }
 

--- a/Monopoly/Models/Cases/StreetProperty.cs
+++ b/Monopoly/Models/Cases/StreetProperty.cs
@@ -7,9 +7,6 @@ namespace Monopoly.Models.Cases
 {
     class StreetProperty : PropertyCase
     {
-        private Image cachePropertyImage = null;
-        private Image cacheBoardImage = null;
-
         public int BuildingCount { get; set; } = 0;
 
         public int BuildingPrice { get; set; }
@@ -78,8 +75,8 @@ namespace Monopoly.Models.Cases
 
         public override Image GetBoardCaseImage()
         {
-            if (cacheBoardImage != null)
-                return cacheBoardImage;
+            if (imageCache.ContainsKey("board-case"))
+                return imageCache["board-case"];
 
             Image img = base.GetBoardCaseImage();
 
@@ -114,22 +111,24 @@ namespace Monopoly.Models.Cases
                 g.DrawString(this.BuildingPrice.ToString(), new Font("Arial", 24), Brushes.White, new PointF(rectangle.X + 34, 155));
             }
 
+            imageCache["board-case"] = img;
+
             return img;
         }
 
-        public override Image GetPropertyCardImage()
+        public override Image GetPropertyCardImage(int scale)
         {
-            if (cachePropertyImage != null)
-                return cachePropertyImage;
+            if (imageCache.ContainsKey($"property-case-{scale}x"))
+                return imageCache[$"property-case-{scale}x"];
 
-            Image img = base.GetPropertyCardImage();
+            Image img = base.GetPropertyCardImage(scale);
 
             using (Graphics g = Graphics.FromImage(img))
             {
                 RectangleF rectangle = g.VisibleClipBounds;
 
                 // Gradient top
-                int headerHeight = 35;
+                int headerHeight = 35 * scale;
                 LinearGradientBrush headerBrush = new LinearGradientBrush(
                     new PointF(0, 0),
                     new PointF(0, headerHeight),
@@ -148,24 +147,24 @@ namespace Monopoly.Models.Cases
                     name = new string(n);
                 }
 
-                g.DrawString(name, new Font("Arial", 10), Brushes.White, new PointF(2.5F, 2.5F));
+                g.DrawString(name, new Font("Arial", 10 * scale), Brushes.White, new PointF(2.5F * scale, 2.5F * scale));
 
                 // Rent
-                int y = 25;
-                int height = 12;
-                DrawPrice(g, y += height, "Loyer", Rents[0]);
-                DrawPrice(g, y += height, "Avec 1 maison", Rents[1]);
-                DrawPrice(g, y += height, "Avec 2 maisons", Rents[2]);
-                DrawPrice(g, y += height, "Avec 3 maisons", Rents[3]);
-                DrawPrice(g, y += height, "Avec 4 maisons", Rents[4]);
-                DrawPrice(g, y += height, "Hôtel", Rents[5]);
+                int y = 25 * scale;
+                int height = 12 * scale;
+                DrawPrice(g, scale, y += height, "Loyer", Rents[0]);
+                DrawPrice(g, scale, y += height, "Avec 1 maison", Rents[1]);
+                DrawPrice(g, scale, y += height, "Avec 2 maisons", Rents[2]);
+                DrawPrice(g, scale, y += height, "Avec 3 maisons", Rents[3]);
+                DrawPrice(g, scale, y += height, "Avec 4 maisons", Rents[4]);
+                DrawPrice(g, scale, y += height, "Hôtel", Rents[5]);
 
-                DrawPrice(g, y += 17, "Hypothèque", Price / 2);
+                DrawPrice(g, scale, y += 17 * scale, "Hypothèque", Price / 2);
 
-                DrawPrice(g, y += 17, "Bâtiment", BuildingPrice);
+                DrawPrice(g, scale, y += 17 * scale, "Bâtiment", BuildingPrice);
             }
 
-            cachePropertyImage = img;
+            imageCache[$"property-case-{scale}x"] = img;
             return img;
         }
 

--- a/Monopoly/Models/Cases/TaxCase.cs
+++ b/Monopoly/Models/Cases/TaxCase.cs
@@ -9,8 +9,6 @@ namespace Monopoly.Models.Cases
 {
     class TaxCase : AbstractCase
     {
-        private Image cacheTaxImage = null;
-
         public enum Tax { IncomeTax = 100, LuxuryTax = 1000 }
 
         public Tax Type { get; private set; }
@@ -29,8 +27,8 @@ namespace Monopoly.Models.Cases
 
         public override Image GetBoardCaseImage()
         {
-            if (cacheTaxImage != null)
-                return cacheTaxImage;
+            if (imageCache.ContainsKey("board-case"))
+                return imageCache["board-case"];
 
             Image img = base.GetBoardCaseImage();
 
@@ -47,6 +45,7 @@ namespace Monopoly.Models.Cases
                 g.DrawImage(Properties.Resources.Tax, new RectangleF(rectangle.X + 10, 87, rectangle.Width - 20, rectangle.Width - 20));
             }
 
+            imageCache["board-case"] = img;
             return img;
         }
     }

--- a/Monopoly/Models/Cases/UtilityProperty.cs
+++ b/Monopoly/Models/Cases/UtilityProperty.cs
@@ -12,17 +12,14 @@ namespace Monopoly.Models.Cases
         const int UTILITY_PRICE = 150;
         private static readonly int[] UTILITY_RENTS = new int[] { 4, 10 };
 
-        private Image cacheCaseImage = null;
-        private Image cacheCardImage = null;
-
         public UtilityProperty(string name) : base(name, UTILITY_PRICE)
         {
 		}
 
         public override Image GetBoardCaseImage()
         {
-            if (cacheCaseImage != null)
-                return cacheCaseImage;
+            if (imageCache.ContainsKey("board-case"))
+                return imageCache["board-case"];
 
             Image img = base.GetBoardCaseImage();
 
@@ -48,17 +45,16 @@ namespace Monopoly.Models.Cases
                 g.DrawImage(image, new RectangleF(rectangle.X + 10, 87, rectangle.Width - 20, rectangle.Width - 20));
             }
 
-            cacheCaseImage = img;
+            imageCache["board-case"] = img;
             return img;
         }
 
-        public override Image GetPropertyCardImage()
+        public override Image GetPropertyCardImage(int scale)
         {
+            if (imageCache.ContainsKey($"property-card-{scale}x"))
+                return imageCache[$"property-card-{scale}x"];
 
-            if (cacheCardImage != null)
-                return cacheCardImage;
-
-            Image img = base.GetPropertyCardImage();
+            Image img = base.GetPropertyCardImage(scale);
 
             using (Graphics g = Graphics.FromImage(img))
             {
@@ -74,24 +70,24 @@ namespace Monopoly.Models.Cases
                     name = new string(n);
                 }
 
-                g.DrawString(name, new Font("Arial", 7), Brushes.White, new PointF(rectangle.X + 2, 50));
+                g.DrawString(name, new Font("Arial", 7 * scale), Brushes.White, new PointF(rectangle.X + 2 * scale, 50 * scale));
 
                 var image = (Name == "Water Delivery") ? Properties.Resources.UtilityWater : Properties.Resources.UtilityEnergy;
-                g.DrawImage(image, new RectangleF(rectangle.X + 2, 2, rectangle.Width - 50, rectangle.Width - 50));
+                g.DrawImage(image, new RectangleF(rectangle.X + 2 * scale, 2 * scale, rectangle.Width - 50 * scale, rectangle.Width - 50 * scale));
 
                 // Rent
-                int y = 62;
-                int height = 12;
-                g.DrawString("Loyer si le bailleur possède", new Font("Arial", 6), Brushes.White, new PointF(rectangle.X + 2, y += height));
-                g.DrawString("1 service :", new Font("Arial", 6), Brushes.White, new PointF(rectangle.X + 2, y += height + 2));
-                DrawPrice(g, y += height -1,"Nombre du dé  x ", UTILITY_RENTS[0]);
-                g.DrawString("2 services :", new Font("Arial", 6), Brushes.White, new PointF(rectangle.X + 2, y += height + 2));
-                DrawPrice(g, y += height -1,"Nombre du dé  x", UTILITY_RENTS[1]);
+                int y = 62 * scale;
+                int height = 12 * scale;
+                g.DrawString("Loyer si le bailleur possède", new Font("Arial", 6 * scale), Brushes.White, new PointF(rectangle.X + 2 * scale, y += height));
+                g.DrawString("1 service :", new Font("Arial", 6 * scale), Brushes.White, new PointF(rectangle.X + 2 * scale, y += height + 2 * scale));
+                DrawPrice(g, scale, y += height - 1 * scale, "Nombre du dé  x ", UTILITY_RENTS[0]);
+                g.DrawString("2 services :", new Font("Arial", 6 * scale), Brushes.White, new PointF(rectangle.X + 2 * scale, y += height + 2 * scale));
+                DrawPrice(g, scale, y += height - 1 * scale, "Nombre du dé  x", UTILITY_RENTS[1]);
 
-                DrawPrice(g, y += height, "Hypothèque", UTILITY_PRICE / 2);
+                DrawPrice(g, scale, y += height, "Hypothèque", UTILITY_PRICE / 2);
             }
 
-            cacheCardImage = img;
+            imageCache[$"property-card-{scale}x"] = img;
             return img;
         }
 

--- a/Monopoly/Views/GameView.cs
+++ b/Monopoly/Views/GameView.cs
@@ -290,7 +290,7 @@ namespace Monopoly.Views
                     {
                         var cardLocation = new PointF(avatarRectangle.Left - cardSize.Width - (cardSize.Width + cardMargin) * i, zoneSize.Bottom - cardSize.Height);
 
-                        Image image = properties[i].GetPropertyCardImage();
+                        Image image = properties[i].GetPropertyCardImage(1);
                         var cardRectangle = new RectangleF(cardLocation, cardSize);
                         g.DrawImage(image, cardRectangle);
                         g.DrawRectangle(Pens.Black, cardRectangle);

--- a/Monopoly/Views/Pawn.cs
+++ b/Monopoly/Views/Pawn.cs
@@ -1,4 +1,5 @@
-﻿using Monopoly.Models;
+﻿using System;
+using Monopoly.Models;
 using System.Collections.Generic;
 using System.Drawing;
 using static Monopoly.Models.Player;

--- a/Monopoly/Views/PropertyManager.cs
+++ b/Monopoly/Views/PropertyManager.cs
@@ -23,7 +23,7 @@ namespace Monopoly.Views
 
             SizeF componentSize = e.Graphics.VisibleClipBounds.Size;
             g.DrawRectangle(Pens.Silver, 0, 0, componentSize.Width - 1, componentSize.Height - 1);
-            g.DrawImage(Property.GetPropertyCardImage(), new RectangleF(0, 0, 100, 150));
+            g.DrawImage(Property.GetPropertyCardImage(1), new RectangleF(0, 0, 100, 150));
         }
     }
 }

--- a/Monopoly/Views/frmGame.cs
+++ b/Monopoly/Views/frmGame.cs
@@ -178,7 +178,7 @@ namespace Monopoly.Views
                             lblCasePropAchetee.Text = $"Vous êtes chez {property.Owner.Name}.{Environment.NewLine}Vous payez {property.GetRent(game)}F de loyer";
                         }
 
-                        pbxCasePropAchetee.BackgroundImage = property.GetPropertyCardImage();
+                        pbxCasePropAchetee.BackgroundImage = property.GetPropertyCardImage(2);
 
                         tabs.TabPages.Add(tabCasePropAchetee);
                     }
@@ -187,13 +187,13 @@ namespace Monopoly.Views
                         if (currentPlayer.Wealth >= property.Price)
                         {
                             btnAcheterPropriete.Enabled = true;
-                            pbxCasePropSimple.BackgroundImage = property.GetPropertyCardImage();
+                            pbxCasePropSimple.BackgroundImage = property.GetPropertyCardImage(2);
                             lblCasePropSimplePrixAchat.Text = "Prix d'achat :" + Environment.NewLine + $"{property.Price}F";
                             tabs.TabPages.Add(tabCasePropSimple);
                         }
                         else
                         {
-                            pbxCasePropSimple.BackgroundImage = property.GetPropertyCardImage();
+                            pbxCasePropSimple.BackgroundImage = property.GetPropertyCardImage(2);
                             lblCasePropSimplePrixAchat.Text = "Vous n'avez pas assez de Flouzz.";
                             btnAcheterPropriete.Enabled = false;
                             tabs.TabPages.Add(tabCasePropSimple);
@@ -220,7 +220,6 @@ namespace Monopoly.Views
             tmrDice.Enabled = false;
 
             // Envoyer le resultat des dés aux pions pour qu'il puissent avancer
-            diceSum = 1;
             game.PlayDice(diceSum);
             UpdateTabs();
         }


### PR DESCRIPTION
Cette PR permet aux cartes de propriétés de s'afficher dans la bonne taille dans la colonne de droite (en x2 au lieu de x1). Elle corrige également des endroits où le cache d'images n'était pas utilisé, améliorant ainsi drastiquement la fluidité du programme.